### PR TITLE
feat: multi-container input and output [PAGOPA-1542] [PAGOPA-1543]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,8 @@ obj/
 
 # custom files
 filename.csv
+
+# Environment
+**/**.env
+/helm/Chart.lock
+**/.terraform/

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
         <azure.storage.queue.version>12.11.4</azure.storage.queue.version>
         <azure.storage.version>8.6.6</azure.storage.version>
         <azure.data.tables.version>12.2.0</azure.data.tables.version>
+        <azure.eventgrid.version>4.20.1</azure.eventgrid.version>
         <resteasy.version>4.5.7.Final</resteasy.version>
         <lombok.version>1.18.22</lombok.version>
         <opencsv.version>5.6</opencsv.version>
@@ -60,6 +61,13 @@
             <groupId>com.azure</groupId>
             <artifactId>azure-data-tables</artifactId>
             <version>${azure.data.tables.version}</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/com.azure/azure-messaging-eventgrid -->
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-messaging-eventgrid</artifactId>
+            <version>${azure.eventgrid.version}</version>
         </dependency>
         <!-- Azure END-->
 

--- a/src/main/java/it/gov/pagopa/canoneunico/csv/validaton/CsvValidation.java
+++ b/src/main/java/it/gov/pagopa/canoneunico/csv/validaton/CsvValidation.java
@@ -2,10 +2,13 @@ package it.gov.pagopa.canoneunico.csv.validaton;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import com.opencsv.bean.CsvToBean;
 import com.opencsv.exceptions.CsvException;
 
+import com.opencsv.exceptions.CsvRequiredFieldEmptyException;
 import it.gov.pagopa.canoneunico.csv.model.PaymentNotice;
 import it.gov.pagopa.canoneunico.model.DebtPositionValidationCsv;
 import it.gov.pagopa.canoneunico.model.error.DebtPositionErrorRow;
@@ -14,15 +17,31 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public class CsvValidation {
 
-    public static DebtPositionValidationCsv checkCsvIsValid(String fileName, CsvToBean<PaymentNotice> csvToBean){
-    	List<PaymentNotice> payments = csvToBean!=null ? csvToBean.parse() : new ArrayList<>();
-    	List<CsvException> parsingExceptions = csvToBean!=null ? csvToBean.getCapturedExceptions(): new ArrayList<>();
-    	DebtPositionValidationCsv debtPosValidation = new DebtPositionValidationCsv();
-    	debtPosValidation.setCsvFilename(fileName);
-    	debtPosValidation.setPayments(payments);
-    	debtPosValidation.setParsingExceptions(parsingExceptions);
-    	debtPosValidation.setTotalNumberRows(payments.size()+parsingExceptions.size());
-    	debtPosValidation.setNumberInvalidRows(parsingExceptions.size());
+    public static DebtPositionValidationCsv checkCsvIsValid(Logger logger, String fileName, CsvToBean<PaymentNotice> csvToBean){
+		DebtPositionValidationCsv debtPosValidation = new DebtPositionValidationCsv();
+		debtPosValidation.setCsvFilename(fileName);
+		List<PaymentNotice> payments = new ArrayList<>();
+
+		if(csvToBean != null) {
+			try {
+				payments = csvToBean.parse();
+			} catch (Exception e) {
+				logger.log(Level.INFO, () -> e.getCause() + " " + e.getMessage());
+				// to work around the error "the exception is never thrown in the corresponding try block", actually the exception is thrown in specific cases
+				if(String.valueOf(e.getCause()).contains("CsvRequiredFieldEmptyException"))
+					csvToBean.getCapturedExceptions().add(
+							new CsvRequiredFieldEmptyException(
+									String.format("%s %s", e.getMessage(), e.getCause())
+							)
+					);
+			}
+		}
+
+		List<CsvException> parsingExceptions = csvToBean!=null ? csvToBean.getCapturedExceptions(): new ArrayList<>();
+		debtPosValidation.setPayments(payments);
+		debtPosValidation.setParsingExceptions(parsingExceptions);
+		debtPosValidation.setTotalNumberRows(payments.size()+parsingExceptions.size());
+		debtPosValidation.setNumberInvalidRows(parsingExceptions.size());
     	CsvValidation.checkConstraintErrors(debtPosValidation);
         return debtPosValidation;
     }

--- a/src/main/java/it/gov/pagopa/canoneunico/functions/CuCreateDebtPosition.java
+++ b/src/main/java/it/gov/pagopa/canoneunico/functions/CuCreateDebtPosition.java
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
  */
 public class CuCreateDebtPosition {
     private final String maxAttempts = System.getenv("MAX_ATTEMPTS");
-    private static final String DUE_DATE = "2025-04-30T23:59:59.999Z"; // todo: extract as env variable
+    private final String PO_DUE_DATE = System.getenv("PO_DUE_DATE");
 
     /**
      * This function will be invoked when a new message is detected in the queue
@@ -181,7 +181,7 @@ public class CuCreateDebtPosition {
                         .amount(row.getAmount())
                         .description("Canone Unico Patrimoniale - CORPORATE")
                         .isPartialPayment(false)
-                        .dueDate(DUE_DATE)
+                        .dueDate(PO_DUE_DATE)
                         .transfer(List.of(Transfer.builder()
                                 .idTransfer("1")
                                 .amount(row.getAmount())

--- a/src/main/java/it/gov/pagopa/canoneunico/functions/CuCsvParsing.java
+++ b/src/main/java/it/gov/pagopa/canoneunico/functions/CuCsvParsing.java
@@ -1,9 +1,12 @@
 package it.gov.pagopa.canoneunico.functions;
 
+import com.azure.core.implementation.serializer.DefaultJsonSerializer;
+import com.azure.core.util.BinaryData;
+import com.azure.messaging.eventgrid.EventGridEvent;
+import com.azure.messaging.eventgrid.systemevents.StorageBlobCreatedEventData;
 import com.microsoft.azure.functions.ExecutionContext;
-import com.microsoft.azure.functions.annotation.BindingName;
-import com.microsoft.azure.functions.annotation.BlobTrigger;
 import com.microsoft.azure.functions.annotation.FunctionName;
+import com.microsoft.azure.functions.annotation.QueueTrigger;
 import com.opencsv.bean.CsvToBean;
 import it.gov.pagopa.canoneunico.csv.model.PaymentNotice;
 import it.gov.pagopa.canoneunico.csv.validaton.CsvValidation;
@@ -11,6 +14,7 @@ import it.gov.pagopa.canoneunico.entity.DebtPositionEntity;
 import it.gov.pagopa.canoneunico.exception.CanoneUnicoException;
 import it.gov.pagopa.canoneunico.model.DebtPositionValidationCsv;
 import it.gov.pagopa.canoneunico.service.CuCsvService;
+import it.gov.pagopa.canoneunico.util.AzuriteStorageUtil;
 
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
@@ -18,6 +22,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Azure Functions with Azure Blob trigger.
@@ -27,6 +33,7 @@ public class CuCsvParsing {
     private static final String LOG_VALIDATION_PREFIX = "[CuCsvParsingFunction Error] Validation Error: ";
     private static final String LOG_VALIDATION_ERROR_HEADER = "Error during csv validation {filename = %s; nLinesError/nTotLines = %s}";
     private static final String LOG_VALIDATION_ERROR_DETAIL = "{line = %s } - {errors = %s}";
+    private static final String INPUT_CONTAINER_NAME = "pagopadcanoneunicosaincsvcontainer"; // TODO TBD
 
     /**
      * This function will be invoked when a new or updated blob is detected at the
@@ -34,25 +41,29 @@ public class CuCsvParsing {
      */
     @FunctionName("CuCsvParsingFunction")
     public void run(
-            @BlobTrigger(name = "BlobCsvTrigger", path = "%INPUT_CSV_BLOB%/{name}", dataType = "binary", connection = "CU_SA_CONNECTION_STRING") byte[] content,
-            @BindingName("name") String fileName, final ExecutionContext context) {
-
+            @QueueTrigger(name = "BlobCreatedEventTrigger", queueName = "%CU_BLOB_EVENTS_QUEUE%", connection = "CU_SA_CONNECTION_STRING") String events,
+            final ExecutionContext context) {
         Logger logger = context.getLogger();
+
         try {
+            ArrayList<String> data = getDataFromEvent(context, events);
+            String corporate = data.get(0);
+            String fileName = data.get(1);
+
             LocalDateTime start = LocalDateTime.now();
             logger.log(Level.INFO, () ->
-                    String.format(
-                            "[CuCsvParsingFunction START] execution started at [%s] - fileName [%s]",
+                    String.format("[CuCsvParsingFunction START] execution started at [%s] - fileName [%s]",
                             start, fileName));
 
+            // read events and download blob and convert to String type
+            BinaryData content = new AzuriteStorageUtil().downloadBlob(context, corporate, INPUT_CONTAINER_NAME + "/" + fileName);
+            if(content == null)
+                throw new CanoneUnicoException(String.format("[CuCsvParsing] Blob not found, corporate: %s, file: %s", corporate, fileName));
+            String converted = new String(content.toBytes(), StandardCharsets.UTF_8);
+
+            // initialize csvService and info from ecConfig
             CuCsvService csvService = this.getCuCsvServiceInstance(logger);
-
-            // initialize info from ecConfig
             csvService.initEcConfigList();
-
-            // string CSV File
-            String converted = new String(content, StandardCharsets.UTF_8);
-
             DebtPositionValidationCsv csvValidation = validateCsv(fileName, logger, csvService, converted);
 
             if (csvValidation.getErrorRows().isEmpty()) {
@@ -62,12 +73,47 @@ public class CuCsvParsing {
                 // If not valid file -> write log error, save on 'error' blob space and delete from 'input' blob space
                 handleInvalidFile(fileName, logger, start, csvService, converted, csvValidation);
             }
+
+            Runtime.getRuntime().gc();
         } catch (Exception e) {
             logger.log(Level.SEVERE, () -> String.format(
-                    LOG_VALIDATION_PREFIX + "[CuCsvParsingFunction ERROR] [%s] Generic Error: error msg = %s - cause = %s",
-                    fileName, e.getMessage(), e.getCause()));
+                    LOG_VALIDATION_PREFIX + "[CuCsvParsingFunction ERROR] [%s] Generic Error: error msg = %s - cause = %s", context.getInvocationId(), e.getMessage(), e.getCause()));
+        }
+    }
+
+    // return data: [container-name, filename]
+    private ArrayList<String> getDataFromEvent(ExecutionContext context, String events) throws CanoneUnicoException {
+        Logger logger = context.getLogger();
+        List<EventGridEvent> eventGridEvents = EventGridEvent.fromString(events);
+
+        if (eventGridEvents.isEmpty()) {
+            throw new CanoneUnicoException("[CuCsvParsing] Empty event list.");
+        }
+        EventGridEvent event = eventGridEvents.get(0);
+        if (!event.getEventType().equals("Microsoft.Storage.BlobCreated")) {
+            throw new CanoneUnicoException("[CuCsvParsing] Event not equals to Microsoft.Storage.BlobCreated.");
         }
 
+        logger.log(Level.INFO, () -> String.format("[id=%s][CuCsvParsing] Call event type %s handler.", context.getInvocationId(), event.getEventType()));
+        StorageBlobCreatedEventData blobData = event.getData().toObject(StorageBlobCreatedEventData.class, new DefaultJsonSerializer());
+
+        if (blobData.getContentLength() > 1e+8 || blobData.getContentLength() == 0) { // if file greater than 100 MB or 0 MB
+            throw new CanoneUnicoException("[CuCsvParsing] File length not allowed: " + blobData.getContentLength() + " MB");
+        }
+
+        logger.log(Level.INFO, () -> String.format("[id=%s][CuCsvParsing] Blob event subject: %s", context.getInvocationId(), event.getSubject()));
+        Pattern pattern = Pattern.compile("containers/(\\w+)/blobs/"+INPUT_CONTAINER_NAME+"/([\\w-]+\\.csv)");
+        Matcher matcher = pattern.matcher(event.getSubject());
+
+        // Check if the pattern is found
+        if (matcher.find()) {
+            ArrayList<String> data = new ArrayList<>();
+            data.add(matcher.group(1)); // corporate container as corporate_id
+            data.add(matcher.group(2)); // filename
+            return data;
+        } else {
+            throw new CanoneUnicoException("[CuCsvParsing] Wrong match in subject: " + event.getSubject());
+        }
     }
 
     private DebtPositionValidationCsv validateCsv(String fileName, Logger logger, CuCsvService csvService, String converted) {

--- a/src/main/java/it/gov/pagopa/canoneunico/functions/CuCsvParsing.java
+++ b/src/main/java/it/gov/pagopa/canoneunico/functions/CuCsvParsing.java
@@ -105,7 +105,8 @@ public class CuCsvParsing {
         logger.log(Level.INFO, () -> String.format("[id=%s][CuCsvParsing] Call event type %s handler.", context.getInvocationId(), event.getEventType()));
         StorageBlobCreatedEventData blobData = event.getData().toObject(StorageBlobCreatedEventData.class, new DefaultJsonSerializer());
 
-        if (blobData.getContentLength() > 1e+8 || blobData.getContentLength() == 0) { // if file greater than 100 MB or 0 MB
+        // to prevent OutOfMemoryException test this corner case is required: if file greater than 100 MB
+        if (blobData.getContentLength() > 1e+8 || blobData.getContentLength() == 0) {
             throw new CanoneUnicoException("[CuCsvParsing] File length not allowed: " + blobData.getContentLength() + " MB");
         }
 

--- a/src/main/java/it/gov/pagopa/canoneunico/functions/CuCsvParsing.java
+++ b/src/main/java/it/gov/pagopa/canoneunico/functions/CuCsvParsing.java
@@ -33,7 +33,7 @@ public class CuCsvParsing {
     private static final String LOG_VALIDATION_PREFIX = "[CuCsvParsingFunction Error] Validation Error: ";
     private static final String LOG_VALIDATION_ERROR_HEADER = "Error during csv validation {filename = %s; nLinesError/nTotLines = %s}";
     private static final String LOG_VALIDATION_ERROR_DETAIL = "{line = %s } - {errors = %s}";
-    private static final String INPUT_CONTAINER_NAME = "pagopadcanoneunicosaincsvcontainer"; // TODO TBD
+    private static final String INPUT_CONTAINER_NAME = "input";
 
     /**
      * This function will be invoked when a new or updated blob is detected at the

--- a/src/main/java/it/gov/pagopa/canoneunico/functions/CuCsvParsing.java
+++ b/src/main/java/it/gov/pagopa/canoneunico/functions/CuCsvParsing.java
@@ -55,10 +55,8 @@ public class CuCsvParsing {
                     String.format("[CuCsvParsingFunction START] execution started at [%s] - fileName [%s]",
                             start, fileName));
 
-            // read events and download blob and convert to String type
-            BinaryData content = new AzuriteStorageUtil().downloadBlob(context, corporate, INPUT_CONTAINER_NAME + "/" + fileName);
-            if(content == null)
-                throw new CanoneUnicoException(String.format("[CuCsvParsing] Blob not found, corporate: %s, file: %s", corporate, fileName));
+            // get byte content and convert to String type
+            BinaryData content = getContent(context, corporate, fileName);
             String converted = new String(content.toBytes(), StandardCharsets.UTF_8);
 
             // initialize csvService and info from ecConfig
@@ -81,8 +79,16 @@ public class CuCsvParsing {
         }
     }
 
+    // return downloaded blob
+    public BinaryData getContent(ExecutionContext context, String corporate, String fileName) throws CanoneUnicoException {
+        BinaryData content = new AzuriteStorageUtil().downloadBlob(context, corporate, INPUT_CONTAINER_NAME + "/" + fileName);
+        if(content == null)
+            throw new CanoneUnicoException(String.format("[CuCsvParsing] Blob not found, corporate: %s, file: %s", corporate, fileName));
+        return content;
+    }
+
     // return data: [container-name, filename]
-    private ArrayList<String> getDataFromEvent(ExecutionContext context, String events) throws CanoneUnicoException {
+    public ArrayList<String> getDataFromEvent(ExecutionContext context, String events) throws CanoneUnicoException {
         Logger logger = context.getLogger();
         List<EventGridEvent> eventGridEvents = EventGridEvent.fromString(events);
 

--- a/src/main/java/it/gov/pagopa/canoneunico/functions/CuGenerateOutputCsv.java
+++ b/src/main/java/it/gov/pagopa/canoneunico/functions/CuGenerateOutputCsv.java
@@ -7,6 +7,7 @@ import com.microsoft.azure.functions.annotation.TimerTrigger;
 import com.microsoft.azure.storage.StorageException;
 import it.gov.pagopa.canoneunico.model.CsvOutModel;
 import it.gov.pagopa.canoneunico.service.DebtPositionService;
+import it.gov.pagopa.canoneunico.util.AzuriteStorageUtil;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -25,8 +26,6 @@ public class CuGenerateOutputCsv {
 
     private final String storageConnectionString = System.getenv("CU_SA_CONNECTION_STRING");
     private final String debtPositionsTable = System.getenv("DEBT_POSITIONS_TABLE");
-    private final String containerBlobIn = System.getenv("INPUT_CSV_BLOB");
-    private final String containerBlobOut = System.getenv("OUTPUT_CSV_BLOB");
 
     /**
      * This function will be invoked periodically according to the specified schedule.
@@ -55,17 +54,17 @@ public class CuGenerateOutputCsv {
             List<List<List<String>>> finalData = data;
             List<CsvOutModel> csvOut =
                     IntStream.range(0, csvFileNamePks.size())
-                            .mapToObj(i -> new CsvOutModel(csvFileNamePks.get(i), finalData.get(i)))
+                            .mapToObj(i -> AzuriteStorageUtil.getOutByBlobKey(csvFileNamePks.get(i), finalData.get(i)))
                             .collect(Collectors.toList());
 
-            csvOut.forEach(e -> {
-                        logger.log(Level.INFO, () -> "[CuGenerateOutputCsvBatchFunction][" + e.getCsvFileName() + "] try to generate output in InputStorage - rows number " + e.getData().size());
+            csvOut.forEach(out -> {
+                        logger.log(Level.INFO, () -> "[CuGenerateOutputCsvBatchFunction][" + out.getContainerName() + "][" + out.getCsvFileName() + "] try to generate output in InputStorage - rows number " + out.getData().size());
                         try {
-                            if (!e.getData().isEmpty()) {
-                                debtPositionService.uploadOutFile(e.getCsvFileName(), e.getData());
+                            if (!out.getData().isEmpty()) {
+                                debtPositionService.uploadOutFile(out.getContainerName(), out.getCsvFileName(), out.getData());
                             }
                         } catch (BlobStorageException | IOException ex) {
-                            logger.log(Level.SEVERE, () -> "[CuGenerateOutputCsvBatchFunction][" + e.getCsvFileName() + "] error: " + ex.getLocalizedMessage());
+                            logger.log(Level.SEVERE, () -> "[CuGenerateOutputCsvBatchFunction][" + out.getCsvFileName() + "] error: " + ex.getLocalizedMessage());
                         }
                     });
         } catch (URISyntaxException | InvalidKeyException | StorageException e) {
@@ -77,8 +76,6 @@ public class CuGenerateOutputCsv {
         return new DebtPositionService(
                 this.storageConnectionString,
                 this.debtPositionsTable,
-                this.containerBlobIn,
-                this.containerBlobOut,
                 logger);
     }
 }

--- a/src/main/java/it/gov/pagopa/canoneunico/functions/CuGenerateOutputCsv.java
+++ b/src/main/java/it/gov/pagopa/canoneunico/functions/CuGenerateOutputCsv.java
@@ -58,19 +58,12 @@ public class CuGenerateOutputCsv {
                             .mapToObj(i -> new CsvOutModel(csvFileNamePks.get(i), finalData.get(i)))
                             .collect(Collectors.toList());
 
-            csvOut.forEach(
-                    e -> {
-                        logger.log(
-                                Level.INFO,
-                                () ->
-                                        "[CuGenerateOutputCsvBatchFunction][" + e.getCsvFileName() + "] try to generate output in InputStorage"
-                                                + " - rows number "
-                                                + e.getData().size());
+            csvOut.forEach(e -> {
+                        logger.log(Level.INFO, () -> "[CuGenerateOutputCsvBatchFunction][" + e.getCsvFileName() + "] try to generate output in InputStorage - rows number " + e.getData().size());
                         try {
                             if (!e.getData().isEmpty()) {
                                 debtPositionService.uploadOutFile(e.getCsvFileName(), e.getData());
                             }
-
                         } catch (BlobStorageException | IOException ex) {
                             logger.log(Level.SEVERE, () -> "[CuGenerateOutputCsvBatchFunction][" + e.getCsvFileName() + "] error: " + ex.getLocalizedMessage());
                         }

--- a/src/main/java/it/gov/pagopa/canoneunico/model/BlobInfo.java
+++ b/src/main/java/it/gov/pagopa/canoneunico/model/BlobInfo.java
@@ -1,0 +1,17 @@
+package it.gov.pagopa.canoneunico.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class BlobInfo {
+    private String container;   // corporate container
+    private String directory;   // one of {input, output, error} directory
+    private String name;        // blob file name
+    private String url;         // blob url: container/directory/blob-name
+}

--- a/src/main/java/it/gov/pagopa/canoneunico/model/CsvOutModel.java
+++ b/src/main/java/it/gov/pagopa/canoneunico/model/CsvOutModel.java
@@ -12,6 +12,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CsvOutModel {
+    private String containerName;
     private String csvFileName;
     private List<List<String>> data;
 }

--- a/src/main/java/it/gov/pagopa/canoneunico/model/PaymentPositionModel.java
+++ b/src/main/java/it/gov/pagopa/canoneunico/model/PaymentPositionModel.java
@@ -15,5 +15,6 @@ public class PaymentPositionModel {
     private String email;
     private String companyName;
     private String validityDate;
+    private Boolean switchToExpired;
     private List<PaymentOptionModel> paymentOption;
 }

--- a/src/main/java/it/gov/pagopa/canoneunico/service/CuCsvService.java
+++ b/src/main/java/it/gov/pagopa/canoneunico/service/CuCsvService.java
@@ -59,7 +59,7 @@ import java.util.stream.IntStream;
 
 @NoArgsConstructor
 public class CuCsvService {
-    private static final String IUPD_PREFIX = "CU_2024_"; // todo: extract as env variable
+    private final String CUP_YEAR = System.getenv("CUP_YEAR");
     private final String iuvGenerationType = System.getenv("IUV_GENERATION_TYPE");
     private final List<EcConfigEntity> organizationsList = new ArrayList<>();
     private String storageConnectionString = System.getenv("CU_SA_CONNECTION_STRING");
@@ -432,7 +432,7 @@ public class CuCsvService {
     }
 
     private String generateIUPD(String iuv) {
-        return IUPD_PREFIX + iuv;
+        return "CU_" + CUP_YEAR + "_" + iuv;
     }
 
 }

--- a/src/main/java/it/gov/pagopa/canoneunico/service/DebtPositionService.java
+++ b/src/main/java/it/gov/pagopa/canoneunico/service/DebtPositionService.java
@@ -37,7 +37,7 @@ public class DebtPositionService {
     public static final String STATUS = "Status";
     private final boolean debugAzurite = Boolean.parseBoolean(System.getenv("DEBUG_AZURITE"));
     private static final String INPUT_CONTAINER_NAME = "input";
-    private static final String OUTPUT_CONTAINER_NAME = "output";
+    private static final String OUTPUT_DIRECTORY_NAME = "output";
     private static final String ERROR_CONTAINER_NAME = "error";
     private static final String DEFAULT_FILE_NAME = "info";
     private final String storageConnectionString;
@@ -175,7 +175,7 @@ public class DebtPositionService {
                 new BlobServiceClientBuilder().connectionString(this.storageConnectionString).buildClient();
         BlobContainerClient blobContainerClient =
                 blobServiceClient.getBlobContainerClient(containerName);
-        BlobClient blobClient = blobContainerClient.getBlobClient(OUTPUT_CONTAINER_NAME + '/' + csvFileName);
+        BlobClient blobClient = blobContainerClient.getBlobClient(OUTPUT_DIRECTORY_NAME + '/' + csvFileName);
 
         File csvOutputFile = new File(csvFileName);
 
@@ -207,7 +207,7 @@ public class DebtPositionService {
     }
 
     private boolean pkBlobFilter(String name) {
-        return name.contains(INPUT_CONTAINER_NAME) && !name.contains(OUTPUT_CONTAINER_NAME)
+        return name.contains(INPUT_CONTAINER_NAME) && !name.contains(OUTPUT_DIRECTORY_NAME)
                        && !name.contains(ERROR_CONTAINER_NAME) && !name.contains(DEFAULT_FILE_NAME) && !name.equals(INPUT_CONTAINER_NAME);
     }
 

--- a/src/main/java/it/gov/pagopa/canoneunico/service/DebtPositionTableService.java
+++ b/src/main/java/it/gov/pagopa/canoneunico/service/DebtPositionTableService.java
@@ -40,12 +40,12 @@ public class DebtPositionTableService {
 
 
     /**
-     * @param filename     used as partition key
+     * @param filekey      used as partition key
      * @param debtPosition elem of the message
      * @param status       to update
      * @param requestId
      */
-    public void updateEntity(String filename, DebtPositionRowMessage debtPosition, boolean status, String requestId) {
+    public void updateEntity(String filekey, DebtPositionRowMessage debtPosition, boolean status, String requestId) {
 
 
         try {
@@ -54,7 +54,7 @@ public class DebtPositionTableService {
                     .getTableReference(this.tableName);
 
             // update the entity
-            DebtPositionEntity entity = new DebtPositionEntity(filename, debtPosition.getId());
+            DebtPositionEntity entity = new DebtPositionEntity(filekey, debtPosition.getId());
             entity.setStatus(status ? Status.CREATED.name() : Status.ERROR.name());
 
             var updateOperation = TableOperation.merge(entity);
@@ -62,7 +62,7 @@ public class DebtPositionTableService {
             table.execute(updateOperation);
 
         } catch (URISyntaxException | StorageException | InvalidKeyException e) {
-            this.logger.log(Level.SEVERE, () -> "[DebtPositionTableService ERROR][requestId=" + requestId + "][" + filename + "] Error " + e);
+            this.logger.log(Level.SEVERE, () -> "[DebtPositionTableService ERROR][requestId=" + requestId + "][" + filekey + "] Error " + e);
         }
     }
 

--- a/src/main/java/it/gov/pagopa/canoneunico/service/GpdClient.java
+++ b/src/main/java/it/gov/pagopa/canoneunico/service/GpdClient.java
@@ -19,8 +19,10 @@ public class GpdClient {
 
     private static final String POST_DEBT_POSITIONS = "/organizations/%s/debtpositions";
     private static final String PUBLISH_DEBT_POSITIONS = "/organizations/%s/debtpositions/%s/publish";
+    private static final String HEADER_SUBSCRIPTION_KEY = "Ocp-Apim-Subscription-Key";
     private static GpdClient instance = null;
     private final String gpdHost = System.getenv("GPD_HOST");
+    private static final String GPD_SUBSCRIPTION_KEY = System.getenv("GPD_SUBSCRIPTION_KEY");
 
     public static GpdClient getInstance() {
         if (instance == null) {
@@ -38,6 +40,7 @@ public class GpdClient {
                     .target(gpdHost + String.format(POST_DEBT_POSITIONS, idPa))
                     .request()
                     .header("X-Request-Id", requestId)
+                    //.header(HEADER_SUBSCRIPTION_KEY, GPD_SUBSCRIPTION_KEY)
                     .accept(MediaType.APPLICATION_JSON)
                     .post(Entity.json(body));
             client.close();
@@ -59,6 +62,7 @@ public class GpdClient {
                     .target(gpdHost + String.format(PUBLISH_DEBT_POSITIONS, idPa, iupd))
                     .request()
                     .header("X-Request-Id", requestId)
+                    //.header(HEADER_SUBSCRIPTION_KEY, GPD_SUBSCRIPTION_KEY)
                     .accept(MediaType.APPLICATION_JSON)
                     .post(Entity.json(null));
             client.close();

--- a/src/main/java/it/gov/pagopa/canoneunico/util/AzuriteStorageUtil.java
+++ b/src/main/java/it/gov/pagopa/canoneunico/util/AzuriteStorageUtil.java
@@ -97,8 +97,8 @@ public class AzuriteStorageUtil {
 
     // based on this format corp_blobName return CsvOutModel instance
     public static CsvOutModel getOutByBlobKey(String blobKey, List<List<String>> data) {
-        String corporate = blobKey.substring(0, blobKey.indexOf("_"));
-        String filename = blobKey.substring(blobKey.indexOf('_')+1);
+        String corporate = blobKey.substring(0, blobKey.indexOf(KEY_SEPARATOR));
+        String filename = blobKey.substring(blobKey.indexOf(KEY_SEPARATOR)+1);
         return new CsvOutModel(corporate, filename, data);
     }
 

--- a/src/main/java/it/gov/pagopa/canoneunico/util/AzuriteStorageUtil.java
+++ b/src/main/java/it/gov/pagopa/canoneunico/util/AzuriteStorageUtil.java
@@ -70,16 +70,16 @@ public class AzuriteStorageUtil {
         }
     }
 
-    public BinaryData downloadBlob(ExecutionContext context, String containerName, String filename) throws CanoneUnicoException {
+    public BinaryData downloadBlob(ExecutionContext context, String containerName, String blob) throws CanoneUnicoException {
         if(!debugAzurite) return null;
 
-        context.getLogger().info(String.format("Download blob %s from container %s", filename, containerName));
+        context.getLogger().info(String.format("Download blob %s from container %s", blob, containerName));
 
         try {
             BlobServiceClient blobServiceClient = new BlobServiceClientBuilder().connectionString(this.storageConnectionString).buildClient();
             BlobContainerClient container = blobServiceClient.getBlobContainerClient(containerName);
             if (!container.exists()) return null;
-            BlobClient blobClient = container.getBlobClient(filename);
+            BlobClient blobClient = container.getBlobClient(blob);
             if (!blobClient.exists()) return null;
 
             return blobClient.downloadContent();

--- a/src/main/java/it/gov/pagopa/canoneunico/util/AzuriteStorageUtil.java
+++ b/src/main/java/it/gov/pagopa/canoneunico/util/AzuriteStorageUtil.java
@@ -32,6 +32,7 @@ import java.util.List;
 @NoArgsConstructor
 public class AzuriteStorageUtil {
 
+    // DEBUG_AZURITE is only for local test purposes: if exist and is enabled executes the storage account resources (table, queue, blob) creation
     private boolean debugAzurite = Boolean.parseBoolean(System.getenv("DEBUG_AZURITE"));
     private String storageConnectionString = System.getenv("CU_SA_CONNECTION_STRING");
     private static final String INPUT_CONTAINER_NAME = "input";
@@ -76,8 +77,6 @@ public class AzuriteStorageUtil {
     }
 
     public BinaryData downloadBlob(ExecutionContext context, String containerName, String blob) throws CanoneUnicoException {
-        if(!debugAzurite) return null;
-
         context.getLogger().info(String.format("[AzuriteStorageUtil] Download blob %s from container %s", blob, containerName));
 
         try {

--- a/src/main/java/it/gov/pagopa/canoneunico/util/AzuriteStorageUtil.java
+++ b/src/main/java/it/gov/pagopa/canoneunico/util/AzuriteStorageUtil.java
@@ -32,7 +32,8 @@ import java.util.List;
 @NoArgsConstructor
 public class AzuriteStorageUtil {
 
-    // DEBUG_AZURITE is only for local test purposes: if exist and is enabled executes the storage account resources (table, queue, blob) creation
+    // DEBUG_AZURITE is for local test purposes only: if it exists and is enabled,
+    // the creation of the storage account resources (table, queue, blob) is performed
     private boolean debugAzurite = Boolean.parseBoolean(System.getenv("DEBUG_AZURITE"));
     private String storageConnectionString = System.getenv("CU_SA_CONNECTION_STRING");
     private static final String INPUT_CONTAINER_NAME = "input";

--- a/src/main/java/it/gov/pagopa/canoneunico/util/AzuriteStorageUtil.java
+++ b/src/main/java/it/gov/pagopa/canoneunico/util/AzuriteStorageUtil.java
@@ -6,6 +6,8 @@ import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.blob.models.BlobContainerItem;
+import com.azure.storage.blob.models.BlobItem;
 import com.azure.storage.blob.models.BlobStorageException;
 import com.microsoft.azure.functions.ExecutionContext;
 import com.microsoft.azure.storage.CloudStorageAccount;
@@ -18,11 +20,13 @@ import com.microsoft.azure.storage.table.CloudTable;
 import com.microsoft.azure.storage.table.CloudTableClient;
 import com.microsoft.azure.storage.table.TableRequestOptions;
 import it.gov.pagopa.canoneunico.exception.CanoneUnicoException;
+import it.gov.pagopa.canoneunico.model.CsvOutModel;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
 import java.net.URISyntaxException;
 import java.security.InvalidKeyException;
+import java.util.List;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -30,7 +34,8 @@ public class AzuriteStorageUtil {
 
     private boolean debugAzurite = Boolean.parseBoolean(System.getenv("DEBUG_AZURITE"));
     private String storageConnectionString = System.getenv("CU_SA_CONNECTION_STRING");
-
+    private static final String INPUT_CONTAINER_NAME = "input";
+    private static final String KEY_SEPARATOR = "_";
 
     // Create a new table
     public void createTable(String tableName) throws URISyntaxException, InvalidKeyException, StorageException {
@@ -73,7 +78,7 @@ public class AzuriteStorageUtil {
     public BinaryData downloadBlob(ExecutionContext context, String containerName, String blob) throws CanoneUnicoException {
         if(!debugAzurite) return null;
 
-        context.getLogger().info(String.format("Download blob %s from container %s", blob, containerName));
+        context.getLogger().info(String.format("[AzuriteStorageUtil] Download blob %s from container %s", blob, containerName));
 
         try {
             BlobServiceClient blobServiceClient = new BlobServiceClientBuilder().connectionString(this.storageConnectionString).buildClient();
@@ -82,9 +87,28 @@ public class AzuriteStorageUtil {
             BlobClient blobClient = container.getBlobClient(blob);
             if (!blobClient.exists()) return null;
 
+            context.getLogger().info(String.format("[AzuriteStorageUtil][Downloaded Blob] Blob name %s, blob URL %s", blobClient.getBlobName(), blobClient.getBlobUrl()));
+
             return blobClient.downloadContent();
         } catch (BlobStorageException e) {
             throw new CanoneUnicoException("[AzureStorageUtil] BlobStorageException " + e.getMessage());
         }
+    }
+
+    // based on this format corp_blobName return CsvOutModel instance
+    public static CsvOutModel getOutByBlobKey(String blobKey, List<List<String>> data) {
+        String corporate = blobKey.substring(0, blobKey.indexOf("_"));
+        String filename = blobKey.substring(blobKey.indexOf('_')+1);
+        return new CsvOutModel(corporate, filename, data);
+    }
+
+    // wrapper for method getBlobKey(String blobContainer, String blobName)
+    public static String getBlobKey(BlobContainerItem blobContainer, BlobItem blobItem) {
+        return getBlobKey(blobContainer.getName(), blobItem.getName().replace(INPUT_CONTAINER_NAME + "/", ""));
+    }
+
+    // key = corp_blobName
+    public static String getBlobKey(String blobContainer, String blobName) {
+        return blobContainer.concat(KEY_SEPARATOR).concat(blobName);
     }
 }

--- a/src/main/java/it/gov/pagopa/canoneunico/util/AzuriteStorageUtil.java
+++ b/src/main/java/it/gov/pagopa/canoneunico/util/AzuriteStorageUtil.java
@@ -1,9 +1,13 @@
 package it.gov.pagopa.canoneunico.util;
 
 
+import com.azure.core.util.BinaryData;
+import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.blob.models.BlobStorageException;
+import com.microsoft.azure.functions.ExecutionContext;
 import com.microsoft.azure.storage.CloudStorageAccount;
 import com.microsoft.azure.storage.OperationContext;
 import com.microsoft.azure.storage.RetryNoRetry;
@@ -13,6 +17,7 @@ import com.microsoft.azure.storage.queue.CloudQueue;
 import com.microsoft.azure.storage.table.CloudTable;
 import com.microsoft.azure.storage.table.CloudTableClient;
 import com.microsoft.azure.storage.table.TableRequestOptions;
+import it.gov.pagopa.canoneunico.exception.CanoneUnicoException;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
@@ -62,6 +67,24 @@ public class AzuriteStorageUtil {
             if (!container.exists()) {
                 blobServiceClient.createBlobContainer(containerName);
             }
+        }
+    }
+
+    public BinaryData downloadBlob(ExecutionContext context, String containerName, String filename) throws CanoneUnicoException {
+        if(!debugAzurite) return null;
+
+        context.getLogger().info(String.format("Download blob %s from container %s", filename, containerName));
+
+        try {
+            BlobServiceClient blobServiceClient = new BlobServiceClientBuilder().connectionString(this.storageConnectionString).buildClient();
+            BlobContainerClient container = blobServiceClient.getBlobContainerClient(containerName);
+            if (!container.exists()) return null;
+            BlobClient blobClient = container.getBlobClient(filename);
+            if (!blobClient.exists()) return null;
+
+            return blobClient.downloadContent();
+        } catch (BlobStorageException e) {
+            throw new CanoneUnicoException("[AzureStorageUtil] BlobStorageException " + e.getMessage());
         }
     }
 }

--- a/src/test/java/it/gov/pagopa/canoneunico/functions/CuCsvParsingTest.java
+++ b/src/test/java/it/gov/pagopa/canoneunico/functions/CuCsvParsingTest.java
@@ -32,7 +32,6 @@ import com.opencsv.bean.CsvToBean;
 import com.opencsv.bean.CsvToBeanBuilder;
 import com.opencsv.bean.HeaderColumnNameMappingStrategy;
 import com.opencsv.enums.CSVReaderNullFieldIndicator;
-import com.opencsv.exceptions.CsvConstraintViolationException;
 
 import it.gov.pagopa.canoneunico.csv.model.PaymentNotice;
 import it.gov.pagopa.canoneunico.csv.validaton.PaymentNoticeVerifier;
@@ -122,13 +121,13 @@ class CuCsvParsingTest {
         doReturn(cuCsvService).when(function).getCuCsvServiceInstance(logger);
         doReturn(BinaryData.fromBytes(file)).when(function).getContent(context, blobInfo);
         doReturn(blobInfo).when(function).getDataFromEvent(context, "events");
-        when(cuCsvService.parseCsv(data)).thenReturn(csvToBean);
+        when(cuCsvService.parseCsvToBean(data)).thenReturn(csvToBean);
 
         function.run("events", context);
 
         verify(context, times(1)).getLogger();
         verify(cuCsvService, times(1)).initEcConfigList();
-        verify(cuCsvService, times(1)).parseCsv(data);
+        verify(cuCsvService, times(1)).parseCsvToBean(data);
         verify(cuCsvService, times(1)).saveDebtPosition("corp_2021-04-21_pagcorp0007_0101108TS.csv", payments);
     }
     
@@ -187,13 +186,13 @@ class CuCsvParsingTest {
         doReturn(cuCsvService).when(function).getCuCsvServiceInstance(logger);
         doReturn(BinaryData.fromBytes(file)).when(function).getContent(context, blobInfo);
         doReturn(blobInfo).when(function).getDataFromEvent(context, "events");
-        when(cuCsvService.parseCsv(data)).thenReturn(csvToBean);
+        when(cuCsvService.parseCsvToBean(data)).thenReturn(csvToBean);
 
         function.run("events", context);
 
         verify(context, times(1)).getLogger();
         verify(cuCsvService, times(1)).initEcConfigList();
-        verify(cuCsvService, times(1)).parseCsv(data);
+        verify(cuCsvService, times(1)).parseCsvToBean(data);
         verify(cuCsvService, times(1)).saveDebtPosition("corp_2021-04-21_pagcorp0007_0101108TS.csv", payments);
     }
 
@@ -227,13 +226,13 @@ class CuCsvParsingTest {
         doReturn(cuCsvService).when(function).getCuCsvServiceInstance(logger);
         doReturn(BinaryData.fromBytes(file)).when(function).getContent(context, blobInfo);
         doReturn(blobInfo).when(function).getDataFromEvent(context, "events");
-        when(cuCsvService.parseCsv(data)).thenReturn(csvToBean);
+        when(cuCsvService.parseCsvToBean(data)).thenReturn(csvToBean);
 
         function.run("events", context);
 
         verify(context, times(1)).getLogger();
         verify(cuCsvService, times(1)).initEcConfigList();
-        verify(cuCsvService, times(1)).parseCsv(data);
+        verify(cuCsvService, times(1)).parseCsvToBean(data);
         verify(cuCsvService, times(1)).uploadCsv(any(), any(), any());
         verify(cuCsvService, times(1)).deleteCsv(any(), any());
     }
@@ -268,13 +267,13 @@ class CuCsvParsingTest {
         doReturn(cuCsvService).when(function).getCuCsvServiceInstance(logger);
         doReturn(BinaryData.fromBytes(file)).when(function).getContent(context, blobInfo);
         doReturn(blobInfo).when(function).getDataFromEvent(context, "events");
-        when(cuCsvService.parseCsv(data)).thenReturn(csvToBean);
+        when(cuCsvService.parseCsvToBean(data)).thenReturn(csvToBean);
 
         function.run("events", context);
 
         verify(context, times(1)).getLogger();
         verify(cuCsvService, times(1)).initEcConfigList();
-        verify(cuCsvService, times(1)).parseCsv(data);
+        verify(cuCsvService, times(1)).parseCsvToBean(data);
         verify(cuCsvService, times(1)).uploadCsv(any(), any(), any());
         verify(cuCsvService, times(1)).deleteCsv(any(), any());
 

--- a/src/test/java/it/gov/pagopa/canoneunico/functions/CuCsvParsingTest.java
+++ b/src/test/java/it/gov/pagopa/canoneunico/functions/CuCsvParsingTest.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
 
+import com.azure.core.util.BinaryData;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -109,15 +110,19 @@ class CuCsvParsingTest {
                 .withThrowExceptions(false)
                 .build();
 
+        byte[] file = data.getBytes();
+        ArrayList<String> eventData = new ArrayList<>(); // data: [container-name, filename]
+        eventData.add("corp");
+        eventData.add("2021-04-21_pagcorp0007_0101108TS.csv");
+
         // precondition
         when(context.getLogger()).thenReturn(logger);
         doReturn(cuCsvService).when(function).getCuCsvServiceInstance(logger);
+        doReturn(BinaryData.fromBytes(file)).when(function).getContent(context, "corp", "2021-04-21_pagcorp0007_0101108TS.csv");
+        doReturn(eventData).when(function).getDataFromEvent(context, "events");
         when(cuCsvService.parseCsv(data)).thenReturn(csvToBean);
-       
 
-        byte[] file = data.getBytes();
-
-        // function.run(file, "2021-04-21_pagcorp0007_0101108TS.csv", context);
+        function.run("events", context);
 
         verify(context, times(1)).getLogger();
         verify(cuCsvService, times(1)).initEcConfigList();
@@ -170,15 +175,19 @@ class CuCsvParsingTest {
                 .withThrowExceptions(false)
                 .build();
 
+        byte[] file = data.getBytes();
+        ArrayList<String> eventData = new ArrayList<>(); // data: [container-name, filename]
+        eventData.add("corp");
+        eventData.add("2021-04-21_pagcorp0007_0101108TS.csv");
+
         // precondition
         when(context.getLogger()).thenReturn(logger);
         doReturn(cuCsvService).when(function).getCuCsvServiceInstance(logger);
+        doReturn(BinaryData.fromBytes(file)).when(function).getContent(context, "corp", "2021-04-21_pagcorp0007_0101108TS.csv");
+        doReturn(eventData).when(function).getDataFromEvent(context, "events");
         when(cuCsvService.parseCsv(data)).thenReturn(csvToBean);
-       
 
-        byte[] file = data.getBytes();
-
-        // function.run(file, "2021-04-21_pagcorp0007_0101108TS.csv", context);
+        function.run("events", context);
 
         verify(context, times(1)).getLogger();
         verify(cuCsvService, times(1)).initEcConfigList();
@@ -206,16 +215,19 @@ class CuCsvParsingTest {
                 .withThrowExceptions(false)
                 .build();
 
+        byte[] file = data.getBytes();
+        ArrayList<String> eventData = new ArrayList<>(); // data: [container-name, filename]
+        eventData.add("corp");
+        eventData.add("2021-04-21_pagcorp0007_0101108TS2_KO.csv");
 
         // precondition
         when(context.getLogger()).thenReturn(logger);
         doReturn(cuCsvService).when(function).getCuCsvServiceInstance(logger);
+        doReturn(BinaryData.fromBytes(file)).when(function).getContent(context, "corp", "2021-04-21_pagcorp0007_0101108TS2_KO.csv");
+        doReturn(eventData).when(function).getDataFromEvent(context, "events");
         when(cuCsvService.parseCsv(data)).thenReturn(csvToBean);
 
-
-        byte[] file = data.getBytes();
-
-        // function.run(file, "2021-04-21_pagcorp0007_0101108TS2_KO.csv", context);
+        function.run("events", context);
 
         verify(context, times(1)).getLogger();
         verify(cuCsvService, times(1)).initEcConfigList();
@@ -245,16 +257,19 @@ class CuCsvParsingTest {
                 .withThrowExceptions(false)
                 .build();
 
+        byte[] file = data.getBytes();
+        ArrayList<String> eventData = new ArrayList<>(); // data: [container-name, filename]
+        eventData.add("corp");
+        eventData.add("2021-04-21_pagcorp0007_0101108TS2_noEC_KO.csv");
 
         // precondition
         when(context.getLogger()).thenReturn(logger);
         doReturn(cuCsvService).when(function).getCuCsvServiceInstance(logger);
+        doReturn(BinaryData.fromBytes(file)).when(function).getContent(context, "corp", "2021-04-21_pagcorp0007_0101108TS2_noEC_KO.csv");
+        doReturn(eventData).when(function).getDataFromEvent(context, "events");
         when(cuCsvService.parseCsv(data)).thenReturn(csvToBean);
 
-
-        byte[] file = data.getBytes();
-
-        // function.run(file, "2021-04-21_pagcorp0007_0101108TS2_noEC_KO.csv", context);
+        function.run("events", context);
 
         verify(context, times(1)).getLogger();
         verify(cuCsvService, times(1)).initEcConfigList();

--- a/src/test/java/it/gov/pagopa/canoneunico/functions/CuCsvParsingTest.java
+++ b/src/test/java/it/gov/pagopa/canoneunico/functions/CuCsvParsingTest.java
@@ -1,5 +1,6 @@
 package it.gov.pagopa.canoneunico.functions;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -18,6 +19,7 @@ import java.util.List;
 import java.util.logging.Logger;
 
 import com.azure.core.util.BinaryData;
+import it.gov.pagopa.canoneunico.model.BlobInfo;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -65,7 +67,7 @@ class CuCsvParsingTest {
     }
 
     @Test
-    void checkParseFileOKTest() throws InvalidKeyException, StorageException, URISyntaxException, CanoneUnicoException, CsvConstraintViolationException {
+    void checkParseFileOKTest() throws InvalidKeyException, StorageException, URISyntaxException, CanoneUnicoException {
 
         ClassLoader classLoader = getClass().getClassLoader();
         InputStream inputStream = classLoader.getResourceAsStream("2021-04-21_pagcorp0007_0101108TS.csv");
@@ -111,15 +113,15 @@ class CuCsvParsingTest {
                 .build();
 
         byte[] file = data.getBytes();
-        ArrayList<String> eventData = new ArrayList<>(); // data: [container-name, filename]
-        eventData.add("corp");
-        eventData.add("2021-04-21_pagcorp0007_0101108TS.csv");
+        BlobInfo blobInfo = BlobInfo.builder()
+                                    .container("corp")
+                                    .name("2021-04-21_pagcorp0007_0101108TS.csv").build();
 
         // precondition
         when(context.getLogger()).thenReturn(logger);
         doReturn(cuCsvService).when(function).getCuCsvServiceInstance(logger);
-        doReturn(BinaryData.fromBytes(file)).when(function).getContent(context, "corp", "2021-04-21_pagcorp0007_0101108TS.csv");
-        doReturn(eventData).when(function).getDataFromEvent(context, "events");
+        doReturn(BinaryData.fromBytes(file)).when(function).getContent(context, blobInfo);
+        doReturn(blobInfo).when(function).getDataFromEvent(context, "events");
         when(cuCsvService.parseCsv(data)).thenReturn(csvToBean);
 
         function.run("events", context);
@@ -127,11 +129,11 @@ class CuCsvParsingTest {
         verify(context, times(1)).getLogger();
         verify(cuCsvService, times(1)).initEcConfigList();
         verify(cuCsvService, times(1)).parseCsv(data);
-        verify(cuCsvService, times(1)).saveDebtPosition("2021-04-21_pagcorp0007_0101108TS.csv", payments);
+        verify(cuCsvService, times(1)).saveDebtPosition("corp_2021-04-21_pagcorp0007_0101108TS.csv", payments);
     }
     
     @Test
-    void checkParseFileOKTest_noIbanValueInEcConfig() throws InvalidKeyException, StorageException, URISyntaxException, CanoneUnicoException, CsvConstraintViolationException {
+    void checkParseFileOKTest_noIbanValueInEcConfig() throws InvalidKeyException, StorageException, URISyntaxException, CanoneUnicoException {
 
         ClassLoader classLoader = getClass().getClassLoader();
         InputStream inputStream = classLoader.getResourceAsStream("2021-04-21_pagcorp0007_0101108TS.csv");
@@ -176,15 +178,15 @@ class CuCsvParsingTest {
                 .build();
 
         byte[] file = data.getBytes();
-        ArrayList<String> eventData = new ArrayList<>(); // data: [container-name, filename]
-        eventData.add("corp");
-        eventData.add("2021-04-21_pagcorp0007_0101108TS.csv");
+        BlobInfo blobInfo = BlobInfo.builder()
+                                    .container("corp")
+                                    .name("2021-04-21_pagcorp0007_0101108TS.csv").build();
 
         // precondition
         when(context.getLogger()).thenReturn(logger);
         doReturn(cuCsvService).when(function).getCuCsvServiceInstance(logger);
-        doReturn(BinaryData.fromBytes(file)).when(function).getContent(context, "corp", "2021-04-21_pagcorp0007_0101108TS.csv");
-        doReturn(eventData).when(function).getDataFromEvent(context, "events");
+        doReturn(BinaryData.fromBytes(file)).when(function).getContent(context, blobInfo);
+        doReturn(blobInfo).when(function).getDataFromEvent(context, "events");
         when(cuCsvService.parseCsv(data)).thenReturn(csvToBean);
 
         function.run("events", context);
@@ -192,7 +194,7 @@ class CuCsvParsingTest {
         verify(context, times(1)).getLogger();
         verify(cuCsvService, times(1)).initEcConfigList();
         verify(cuCsvService, times(1)).parseCsv(data);
-        verify(cuCsvService, times(1)).saveDebtPosition("2021-04-21_pagcorp0007_0101108TS.csv", payments);
+        verify(cuCsvService, times(1)).saveDebtPosition("corp_2021-04-21_pagcorp0007_0101108TS.csv", payments);
     }
 
     @Test
@@ -216,15 +218,15 @@ class CuCsvParsingTest {
                 .build();
 
         byte[] file = data.getBytes();
-        ArrayList<String> eventData = new ArrayList<>(); // data: [container-name, filename]
-        eventData.add("corp");
-        eventData.add("2021-04-21_pagcorp0007_0101108TS2_KO.csv");
+        BlobInfo blobInfo = BlobInfo.builder()
+                                    .container("corp")
+                                    .name("2021-04-21_pagcorp0007_0101108TS.csv").build();
 
         // precondition
         when(context.getLogger()).thenReturn(logger);
         doReturn(cuCsvService).when(function).getCuCsvServiceInstance(logger);
-        doReturn(BinaryData.fromBytes(file)).when(function).getContent(context, "corp", "2021-04-21_pagcorp0007_0101108TS2_KO.csv");
-        doReturn(eventData).when(function).getDataFromEvent(context, "events");
+        doReturn(BinaryData.fromBytes(file)).when(function).getContent(context, blobInfo);
+        doReturn(blobInfo).when(function).getDataFromEvent(context, "events");
         when(cuCsvService.parseCsv(data)).thenReturn(csvToBean);
 
         function.run("events", context);
@@ -232,9 +234,8 @@ class CuCsvParsingTest {
         verify(context, times(1)).getLogger();
         verify(cuCsvService, times(1)).initEcConfigList();
         verify(cuCsvService, times(1)).parseCsv(data);
-        verify(cuCsvService, times(1)).uploadCsv("2021-04-21_pagcorp0007_0101108TS2_KO.csv", null);
-        verify(cuCsvService, times(1)).deleteCsv("2021-04-21_pagcorp0007_0101108TS2_KO.csv");
-
+        verify(cuCsvService, times(1)).uploadCsv(any(), any(), any());
+        verify(cuCsvService, times(1)).deleteCsv(any(), any());
     }
     
     @Test
@@ -258,15 +259,15 @@ class CuCsvParsingTest {
                 .build();
 
         byte[] file = data.getBytes();
-        ArrayList<String> eventData = new ArrayList<>(); // data: [container-name, filename]
-        eventData.add("corp");
-        eventData.add("2021-04-21_pagcorp0007_0101108TS2_noEC_KO.csv");
+        BlobInfo blobInfo = BlobInfo.builder()
+                                    .container("corp")
+                                    .name("2021-04-21_pagcorp0007_0101108TS.csv").build();
 
         // precondition
         when(context.getLogger()).thenReturn(logger);
         doReturn(cuCsvService).when(function).getCuCsvServiceInstance(logger);
-        doReturn(BinaryData.fromBytes(file)).when(function).getContent(context, "corp", "2021-04-21_pagcorp0007_0101108TS2_noEC_KO.csv");
-        doReturn(eventData).when(function).getDataFromEvent(context, "events");
+        doReturn(BinaryData.fromBytes(file)).when(function).getContent(context, blobInfo);
+        doReturn(blobInfo).when(function).getDataFromEvent(context, "events");
         when(cuCsvService.parseCsv(data)).thenReturn(csvToBean);
 
         function.run("events", context);
@@ -274,8 +275,8 @@ class CuCsvParsingTest {
         verify(context, times(1)).getLogger();
         verify(cuCsvService, times(1)).initEcConfigList();
         verify(cuCsvService, times(1)).parseCsv(data);
-        verify(cuCsvService, times(1)).uploadCsv("2021-04-21_pagcorp0007_0101108TS2_noEC_KO.csv", null);
-        verify(cuCsvService, times(1)).deleteCsv("2021-04-21_pagcorp0007_0101108TS2_noEC_KO.csv");
+        verify(cuCsvService, times(1)).uploadCsv(any(), any(), any());
+        verify(cuCsvService, times(1)).deleteCsv(any(), any());
 
     }
 }

--- a/src/test/java/it/gov/pagopa/canoneunico/functions/CuCsvParsingTest.java
+++ b/src/test/java/it/gov/pagopa/canoneunico/functions/CuCsvParsingTest.java
@@ -117,7 +117,7 @@ class CuCsvParsingTest {
 
         byte[] file = data.getBytes();
 
-        function.run(file, "2021-04-21_pagcorp0007_0101108TS.csv", context);
+        // function.run(file, "2021-04-21_pagcorp0007_0101108TS.csv", context);
 
         verify(context, times(1)).getLogger();
         verify(cuCsvService, times(1)).initEcConfigList();
@@ -178,7 +178,7 @@ class CuCsvParsingTest {
 
         byte[] file = data.getBytes();
 
-        function.run(file, "2021-04-21_pagcorp0007_0101108TS.csv", context);
+        // function.run(file, "2021-04-21_pagcorp0007_0101108TS.csv", context);
 
         verify(context, times(1)).getLogger();
         verify(cuCsvService, times(1)).initEcConfigList();
@@ -215,7 +215,7 @@ class CuCsvParsingTest {
 
         byte[] file = data.getBytes();
 
-        function.run(file, "2021-04-21_pagcorp0007_0101108TS2_KO.csv", context);
+        // function.run(file, "2021-04-21_pagcorp0007_0101108TS2_KO.csv", context);
 
         verify(context, times(1)).getLogger();
         verify(cuCsvService, times(1)).initEcConfigList();
@@ -254,7 +254,7 @@ class CuCsvParsingTest {
 
         byte[] file = data.getBytes();
 
-        function.run(file, "2021-04-21_pagcorp0007_0101108TS2_noEC_KO.csv", context);
+        // function.run(file, "2021-04-21_pagcorp0007_0101108TS2_noEC_KO.csv", context);
 
         verify(context, times(1)).getLogger();
         verify(cuCsvService, times(1)).initEcConfigList();

--- a/src/test/java/it/gov/pagopa/canoneunico/functions/CuGenerateOutputCsvTest.java
+++ b/src/test/java/it/gov/pagopa/canoneunico/functions/CuGenerateOutputCsvTest.java
@@ -48,7 +48,7 @@ class CuGenerateOutputCsvTest {
         // Asserts
         verify(context, times(1)).getLogger();
         verify(debtPositionService, times(1)).getDebtPositionListByPk(any());
-        verify(debtPositionService, times(0)).uploadOutFile(anyString(), any());
+        verify(debtPositionService, times(0)).uploadOutFile(anyString(), anyString(), any());
 
     }
 

--- a/src/test/java/it/gov/pagopa/canoneunico/service/CuCsvServiceTest.java
+++ b/src/test/java/it/gov/pagopa/canoneunico/service/CuCsvServiceTest.java
@@ -169,7 +169,7 @@ class CuCsvServiceTest {
         csv.append(System.lineSeparator());
         csv.append(row);
       
-        CsvToBean<PaymentNotice> csvToBean = csvService.parseCsv(csv.toString());
+        CsvToBean<PaymentNotice> csvToBean = csvService.parseCsvToBean(csv.toString());
         assertNotNull(csvToBean);
         assertEquals(1, csvToBean.parse().size());
         
@@ -215,7 +215,7 @@ class CuCsvServiceTest {
         csv.append(System.lineSeparator());
         csv.append(row);
       
-        CsvToBean<PaymentNotice> csvToBean = csvService.parseCsv(csv.toString());
+        CsvToBean<PaymentNotice> csvToBean = csvService.parseCsvToBean(csv.toString());
         assertNotNull(csvToBean);
         assertEquals(1, csvToBean.parse().size());
         
@@ -266,7 +266,7 @@ class CuCsvServiceTest {
         csv.append(System.lineSeparator());
         csv.append(row);
       
-        CsvToBean<PaymentNotice> csvToBean = csvService.parseCsv(csv.toString());
+        CsvToBean<PaymentNotice> csvToBean = csvService.parseCsvToBean(csv.toString());
         assertNotNull(csvToBean);
         // Il parsing del file va in errore per id_catasto duplicato quindi la size è 0
         assertEquals(0, csvToBean.parse().size());
@@ -318,7 +318,7 @@ class CuCsvServiceTest {
         csv.append(System.lineSeparator());
         csv.append(row);
       
-        CsvToBean<PaymentNotice> csvToBean = csvService.parseCsv(csv.toString());
+        CsvToBean<PaymentNotice> csvToBean = csvService.parseCsvToBean(csv.toString());
         assertNotNull(csvToBean);
         // Il parsing del file va in errore per id_istat duplicato quindi la size è 0
         assertEquals(0, csvToBean.parse().size());
@@ -340,7 +340,7 @@ class CuCsvServiceTest {
         csv.append(System.lineSeparator());
         csv.append(row);
       
-        CsvToBean<PaymentNotice> csvToBean = csvService.parseCsv(csv.toString());
+        CsvToBean<PaymentNotice> csvToBean = csvService.parseCsvToBean(csv.toString());
         assertNotNull(csvToBean);
         assertEquals(0, csvToBean.parse().size());
         assertEquals(1, csvToBean.getCapturedExceptions().size());
@@ -362,7 +362,7 @@ class CuCsvServiceTest {
         csv.append(System.lineSeparator());
         csv.append(row);
       
-        CsvToBean<PaymentNotice> csvToBean = csvService.parseCsv(csv.toString());
+        CsvToBean<PaymentNotice> csvToBean = csvService.parseCsvToBean(csv.toString());
         assertNotNull(csvToBean);
         assertEquals(0, csvToBean.parse().size());
         assertEquals(1, csvToBean.getCapturedExceptions().size());
@@ -767,7 +767,7 @@ class CuCsvServiceTest {
         validCsv.getErrorRows().add(rowErr);
         
         
-        String errorFile = csvService.generateErrorCsv(csv.toString(), validCsv);
+        String errorFile = csvService.generateRowsErrorCsv(csv.toString(), validCsv);
         assertNotNull(errorFile);
     }
     

--- a/src/test/java/it/gov/pagopa/canoneunico/service/CuCsvServiceTest.java
+++ b/src/test/java/it/gov/pagopa/canoneunico/service/CuCsvServiceTest.java
@@ -329,7 +329,7 @@ class CuCsvServiceTest {
     void parseCsv_KO_Amount() {
         Logger logger = Logger.getLogger("testlogging");
 
-        var csvService = spy(new CuCsvService(storageConnectionString, "input", "error", "debtPositionT", "debtPositionQ", logger));
+        var csvService = spy(new CuCsvService(storageConnectionString, "debtPositionT", "debtPositionQ", logger));
         
         StringWriter csv = new StringWriter();
         
@@ -351,7 +351,7 @@ class CuCsvServiceTest {
     void parseCsv_KO_Mutual_Exclusion() {
         Logger logger = Logger.getLogger("testlogging");
 
-        var csvService = spy(new CuCsvService(storageConnectionString, "input", "error", "debtPositionT", "debtPositionQ", logger));
+        var csvService = spy(new CuCsvService(storageConnectionString, "debtPositionT", "debtPositionQ", logger));
         
         StringWriter csv = new StringWriter();
         
@@ -373,7 +373,7 @@ class CuCsvServiceTest {
     void uploadCsv() {
         Logger logger = Logger.getLogger("testlogging");
 
-        var csvService = spy(new CuCsvService(storageConnectionString, "input", "error", "debtPositionT", "debtPositionQ", logger));
+        var csvService = spy(new CuCsvService(storageConnectionString, "debtPositionT", "debtPositionQ", logger));
         
         BlobServiceClient blobServiceClient = new BlobServiceClientBuilder()
                 .connectionString(this.storageConnectionString).buildClient();
@@ -381,7 +381,7 @@ class CuCsvServiceTest {
         if (!container.exists()) {
             blobServiceClient.createBlobContainer("error");
         }
-        csvService.uploadCsv("fileName.txt", "test content string");
+        csvService.uploadCsv("testcontainer", "fileName.txt", "test content string");
         // se arrivo a questa chiamata l'upload è andato a buon fine
         assertTrue(true);
         
@@ -391,7 +391,7 @@ class CuCsvServiceTest {
     void deleteCsv() {
         Logger logger = Logger.getLogger("testlogging");
 
-        var csvService = spy(new CuCsvService(storageConnectionString, "input", "error", "debtPositionT", "debtPositionQ", logger));
+        var csvService = spy(new CuCsvService(storageConnectionString, "debtPositionT", "debtPositionQ", logger));
         
         BlobServiceClient blobServiceClient = new BlobServiceClientBuilder()
                 .connectionString(this.storageConnectionString).buildClient();
@@ -402,8 +402,9 @@ class CuCsvServiceTest {
 		BlockBlobClient blockBlobClient = container.getBlobClient("fileName.txt").getBlockBlobClient();
         InputStream stream = new ByteArrayInputStream("test content string".getBytes());
         blockBlobClient.upload(stream, "test content string".getBytes().length);
-        
-        csvService.deleteCsv("fileName.txt");
+
+        csvService.deleteCsv("testcontainer", "fileName.txt");
+
         // se arrivo a questa chiamata la delete è andata a buon fine
         assertTrue(true);
         
@@ -521,7 +522,7 @@ class CuCsvServiceTest {
     void pushDebtPosition() throws InvalidKeyException, URISyntaxException, StorageException {
         Logger logger = Logger.getLogger("testlogging");
 
-        var csvService = spy(new CuCsvService(storageConnectionString, "input", "error", "debtPositionT", "queue", logger));
+        var csvService = spy(new CuCsvService(storageConnectionString, "debtPositionT", "queue", logger));
         
         CloudQueue queue = CloudStorageAccount.parse(storageConnectionString).createCloudQueueClient()
                 .getQueueReference("queue");
@@ -551,7 +552,7 @@ class CuCsvServiceTest {
     void pushDebtPositionSkipped() throws InvalidKeyException, URISyntaxException, StorageException {
         Logger logger = Logger.getLogger("testlogging");
 
-        var csvService = spy(new CuCsvService(storageConnectionString, "input", "error", "debtPositionT", "queue", logger));
+        var csvService = spy(new CuCsvService(storageConnectionString, "debtPositionT", "queue", logger));
         
         CloudQueue queue = CloudStorageAccount.parse(storageConnectionString).createCloudQueueClient()
                 .getQueueReference("queue");
@@ -581,7 +582,7 @@ class CuCsvServiceTest {
     void addDebtPositionEntityList() throws InvalidKeyException, URISyntaxException, StorageException {
         Logger logger = Logger.getLogger("testlogging");
 
-        var csvService = spy(new CuCsvService(storageConnectionString, "input", "error", "debtPositionT", "debtPositionQ", logger));
+        var csvService = spy(new CuCsvService(storageConnectionString, "debtPositionT", "debtPositionQ", logger));
         
         CloudStorageAccount cloudStorageAccount = CloudStorageAccount.parse(storageConnectionString);
         CloudTableClient cloudTableClient = cloudStorageAccount.createCloudTableClient();
@@ -621,7 +622,7 @@ class CuCsvServiceTest {
     void addDebtPositionMsg() throws InvalidKeyException, URISyntaxException, StorageException, JsonProcessingException {
         Logger logger = Logger.getLogger("testlogging");
 
-        var csvService = spy(new CuCsvService(storageConnectionString, "input", "error", "debtPositionT", "queue", logger));
+        var csvService = spy(new CuCsvService(storageConnectionString, "debtPositionT", "queue", logger));
         
         CloudQueue queue = CloudStorageAccount.parse(storageConnectionString).createCloudQueueClient()
                 .getQueueReference("queue");
@@ -745,7 +746,7 @@ class CuCsvServiceTest {
     void generateErrorCsv() {
         Logger logger = Logger.getLogger("testlogging");
 
-        var csvService = spy(new CuCsvService(storageConnectionString, "input", "error", "debtPositionT", "debtPositionQ", logger));
+        var csvService = spy(new CuCsvService(storageConnectionString, "debtPositionT", "debtPositionQ", logger));
         
         StringWriter csv = new StringWriter();
         

--- a/src/test/java/it/gov/pagopa/canoneunico/service/CuCsvServiceTest.java
+++ b/src/test/java/it/gov/pagopa/canoneunico/service/CuCsvServiceTest.java
@@ -372,16 +372,17 @@ class CuCsvServiceTest {
     @Test
     void uploadCsv() {
         Logger logger = Logger.getLogger("testlogging");
+        String corporateContainer = "corporate";
 
         var csvService = spy(new CuCsvService(storageConnectionString, "debtPositionT", "debtPositionQ", logger));
         
         BlobServiceClient blobServiceClient = new BlobServiceClientBuilder()
                 .connectionString(this.storageConnectionString).buildClient();
-        BlobContainerClient container = blobServiceClient.getBlobContainerClient("error");
+        BlobContainerClient container = blobServiceClient.getBlobContainerClient(corporateContainer);
         if (!container.exists()) {
-            blobServiceClient.createBlobContainer("error");
+            blobServiceClient.createBlobContainer(corporateContainer);
         }
-        csvService.uploadCsv("testcontainer", "fileName.txt", "test content string");
+        csvService.uploadCsv(corporateContainer, "fileName.txt", "test content string");
         // se arrivo a questa chiamata l'upload è andato a buon fine
         assertTrue(true);
         
@@ -390,20 +391,20 @@ class CuCsvServiceTest {
     @Test
     void deleteCsv() {
         Logger logger = Logger.getLogger("testlogging");
-
+        String corporateContainer = "input";
         var csvService = spy(new CuCsvService(storageConnectionString, "debtPositionT", "debtPositionQ", logger));
         
         BlobServiceClient blobServiceClient = new BlobServiceClientBuilder()
                 .connectionString(this.storageConnectionString).buildClient();
-        BlobContainerClient container = blobServiceClient.getBlobContainerClient("input");
+        BlobContainerClient container = blobServiceClient.getBlobContainerClient(corporateContainer);
         if (!container.exists()) {
-            blobServiceClient.createBlobContainer("input");
+            blobServiceClient.createBlobContainer(corporateContainer);
         }
 		BlockBlobClient blockBlobClient = container.getBlobClient("fileName.txt").getBlockBlobClient();
         InputStream stream = new ByteArrayInputStream("test content string".getBytes());
         blockBlobClient.upload(stream, "test content string".getBytes().length);
 
-        csvService.deleteCsv("testcontainer", "fileName.txt");
+        csvService.deleteCsv(corporateContainer, "fileName.txt");
 
         // se arrivo a questa chiamata la delete è andata a buon fine
         assertTrue(true);

--- a/src/test/java/it/gov/pagopa/canoneunico/service/DebtPositionServiceIntegrationTest.java
+++ b/src/test/java/it/gov/pagopa/canoneunico/service/DebtPositionServiceIntegrationTest.java
@@ -83,7 +83,7 @@ class DebtPositionServiceIntegrationTest {
         int noBlob = 10;
 
         for (int i = 0; i < noBlob; i++) {
-            blobClient = containerClient.getBlobClient("csv" + i + ".csv");
+            blobClient = containerClient.getBlobClient("input/csv" + i + ".csv");
             targetStream = new ByteArrayInputStream(initialString.getBytes());
             blobClient.upload(BinaryData.fromStream(targetStream));
         }
@@ -136,7 +136,11 @@ class DebtPositionServiceIntegrationTest {
                 CloudStorageAccount.parse(storageConnectionString)
                         .createCloudTableClient()
                         .getTableReference(debtPositionsTable);
-//    table.createIfNotExists();
+        try {
+            table.createIfNotExists();
+        } catch (StorageException e) {
+            // continue
+        }
 
         DebtPositionEntity debtPositionEntity;
         for (int j = 0; j < 3; j++) {
@@ -202,6 +206,12 @@ class DebtPositionServiceIntegrationTest {
                 .createCloudTableClient()
                 .getTableReference(debtPositionsTable);
 
+        try {
+            table.createIfNotExists();
+        } catch (StorageException e) {
+            // continue
+        }
+
         //insert data into table
         var debtPositionEntity1 = getMockDebtPosition("1", Status.CREATED.name());
         var debtPositionEntity2 = getMockDebtPosition("2", Status.SKIPPED.name());
@@ -262,23 +272,22 @@ class DebtPositionServiceIntegrationTest {
         BlobServiceClient blobServiceClient =
                 new BlobServiceClientBuilder().connectionString(this.storageConnectionString).buildClient();
 
-        BlobContainerClient containerClientBlobIn = blobServiceClient.getBlobContainerClient(containerBlobIn);
-        if (!containerClientBlobIn.exists()) {
-            containerClientBlobIn = blobServiceClient.createBlobContainer(containerBlobIn);
+        final String corpContainer = "corp";
+        BlobContainerClient containerCorporate = blobServiceClient.getBlobContainerClient(corpContainer);
+        if (!containerCorporate.exists()) {
+            containerCorporate = blobServiceClient.createBlobContainer(corpContainer);
         }
-
 
         String initialString = "test-text";
         InputStream targetStream;
         BlobClient blobClient;
 
         String csvFileName = "filename.csv";
+        String csvFilePath = "input/filename.csv";
 
-        blobClient = containerClientBlobIn.getBlobClient(csvFileName);
+        blobClient = containerCorporate.getBlobClient(csvFilePath);
         targetStream = new ByteArrayInputStream(initialString.getBytes());
         blobClient.upload(BinaryData.fromStream(targetStream));
-
-        BlobContainerClient containerClientBlobOut = blobServiceClient.createBlobContainer(containerBlobOut);
 
         List<List<String>> dataLines = new ArrayList<>();
         List<String> row1 = new ArrayList<>();
@@ -298,16 +307,13 @@ class DebtPositionServiceIntegrationTest {
         dataLines.add(row3);
         dataLines.add(row2);
 
-        debtPositionService.uploadOutFile(containerBlobOut, csvFileName, dataLines);
+        debtPositionService.uploadOutFile(corpContainer, csvFileName, dataLines);
 
 
-        List<String> fileNamesOut = containerClientBlobOut.listBlobs().stream().map(BlobItem::getName)
+        List<String> corporateFiles = containerCorporate.listBlobs().stream().map(BlobItem::getName)
                 .collect(Collectors.toList());
 
-        List<String> fileNamesIn = containerClientBlobIn.listBlobs().stream().map(BlobItem::getName)
-                .collect(Collectors.toList());
-
-        assertTrue(fileNamesOut.contains(csvFileName));
-        assertTrue(!fileNamesIn.contains(csvFileName));
+        assertTrue(corporateFiles.contains("output/" + csvFileName));
+        assertTrue(!corporateFiles.contains("input/" + csvFileName));
     }
 }

--- a/src/test/java/it/gov/pagopa/canoneunico/service/DebtPositionServiceIntegrationTest.java
+++ b/src/test/java/it/gov/pagopa/canoneunico/service/DebtPositionServiceIntegrationTest.java
@@ -65,17 +65,12 @@ class DebtPositionServiceIntegrationTest {
     DebtPositionService debtPositionService;
 
     @Test
-    void getCsvFilePkTest()
-            throws ParseException, DatatypeConfigurationException, InvalidKeyException,
-            URISyntaxException {
-
+    void getCsvFilePkTest() {
         debtPositionService =
                 spy(
                         new DebtPositionService(
                                 storageConnectionString,
                                 debtPositionsTable,
-                                containerBlobIn,
-                                containerBlobOut,
                                 logger));
 
         BlobServiceClient blobServiceClient =
@@ -109,8 +104,6 @@ class DebtPositionServiceIntegrationTest {
                         new DebtPositionService(
                                 storageConnectionString,
                                 debtPositionsTable,
-                                containerBlobIn,
-                                containerBlobOut,
                                 logger));
 
         CloudTable table =
@@ -137,8 +130,6 @@ class DebtPositionServiceIntegrationTest {
                         new DebtPositionService(
                                 storageConnectionString,
                                 debtPositionsTable,
-                                containerBlobIn,
-                                containerBlobOut,
                                 logger));
 
         CloudTable table =
@@ -205,8 +196,6 @@ class DebtPositionServiceIntegrationTest {
         debtPositionService = spy(new DebtPositionService(
                 storageConnectionString,
                 debtPositionsTable,
-                containerBlobIn,
-                containerBlobOut,
                 logger));
 
         CloudTable table = CloudStorageAccount.parse(storageConnectionString)
@@ -268,8 +257,6 @@ class DebtPositionServiceIntegrationTest {
                         new DebtPositionService(
                                 storageConnectionString,
                                 debtPositionsTable,
-                                containerBlobIn,
-                                containerBlobOut,
                                 logger));
 
         BlobServiceClient blobServiceClient =
@@ -311,7 +298,7 @@ class DebtPositionServiceIntegrationTest {
         dataLines.add(row3);
         dataLines.add(row2);
 
-        debtPositionService.uploadOutFile(csvFileName, dataLines);
+        debtPositionService.uploadOutFile(containerBlobOut, csvFileName, dataLines);
 
 
         List<String> fileNamesOut = containerClientBlobOut.listBlobs().stream().map(BlobItem::getName)
@@ -322,6 +309,5 @@ class DebtPositionServiceIntegrationTest {
 
         assertTrue(fileNamesOut.contains(csvFileName));
         assertTrue(!fileNamesIn.contains(csvFileName));
-
     }
 }

--- a/test/blob_utils.py
+++ b/test/blob_utils.py
@@ -57,9 +57,9 @@ if action == Action.Upload:
                         "Lorem ipsum", "lorem@pec.loremit", "", ""]
                 # write the data
                 writer.writerow(data)
-
+    blob = "input/" + file
     os.system(
-        f'az storage blob upload --account-name {account_name} --auth-mode key -c {container_name} -f {path}/{file} -n {file}')
+        f'az storage blob upload --account-name {account_name} --auth-mode key -c {container_name} -f {path}/{file} -n {blob}')
 
 elif action == Action.List:
     os.system(

--- a/test/blob_utils.py
+++ b/test/blob_utils.py
@@ -28,6 +28,12 @@ parser.add_argument('--account-name', metavar='ACCOUNT_NAME', type=str, nargs='?
                     help='Azure account name (default: pagopadcanoneunicosa)')
 parser.add_argument('--container-name', metavar='CONTAINER_NAME', type=str, nargs='?',
                     help='Azure container name (default: pagopadcanoneunicosaincsvcontainer)')
+parser.add_argument('--invalid_csv', metavar='INVALID_CSV', type=bool, nargs='?',
+                    help='Invalid CSV format file (default: False)')
+parser.add_argument('--invalid_csv_header', metavar='INVALID_CSV_HEADER', type=bool, nargs='?',
+                    help='Invalid CSV header file (default: False)')
+parser.add_argument('--not_mutually_id', metavar='NOT_MUTUALLY_ID', type=bool, nargs='?',
+                    help='Invalid CSV header file (default: False)')
 args = parser.parse_args()
 
 action = args.action
@@ -37,26 +43,47 @@ rows = args.rows
 pa_fiscalcode = args.pa_fiscalcode or "11111111111"
 account_name = args.account_name or "pagopadcanoneunicosa"
 container_name = args.container_name or "pagopadcanoneunicosaincsvcontainer"
+invalid_csv = args.invalid_csv or False
+invalid_csv_header = args.invalid_csv_header or False
+not_mutually_id = args.not_mutually_id or False
 
 if action == Action.Upload:
     os.system(f'mkdir -p {path}')
     if rows:
         with open(path + "/" + file, 'w', encoding='UTF8') as f:
             writer = csv.writer(f, delimiter=';')
-            header = ["id", "pa_id_istat", "pa_id_catasto", "pa_id_fiscal_code", "pa_id_cbill", "pa_pec_email",
-                      "pa_referent_email",
-                      "pa_referent_name", "amount", "debtor_id_fiscal_code", "debtor_name", "debtor_email",
-                      "payment_notice_number",
-                      "note"]
+            
+            if not(invalid_csv_header):
+                header = ["id", "pa_id_istat", "pa_id_catasto", "pa_id_fiscal_code", "pa_id_cbill", "pa_pec_email",
+                        "pa_referent_email",
+                        "pa_referent_name", "amount", "debtor_id_fiscal_code", "debtor_name", "debtor_email",
+                        "payment_notice_number",
+                        "note"]
+            else:
+                header = ["a", "b", "c", "d", "e", "pa_pec_email",
+                        "pa_referent_email",
+                        "pa_referent_name", "amount", "debtor_id_fiscal_code", "debtor_name", "debtor_email",
+                        "payment_notice_number",
+                        "note"]
             # write the header
             writer.writerow(header)
-
-            for i in range(1, rows + 1):
-                data = [i, "", "", pa_fiscalcode, "", "fake@email.com", "pa_referent_email", "pa_referent_name",
-                        random.randint(1, 100000), str(random.randint(0, 99999999999)).zfill(11),
-                        "Lorem ipsum", "lorem@pec.loremit", "", ""]
-                # write the data
-                writer.writerow(data)
+            if not(invalid_csv):
+                for i in range(1, rows + 1):
+                    data = [i, "", "", pa_fiscalcode, "", "fake@email.com", "pa_referent_email", "pa_referent_name",
+                            random.randint(1, 100000), str(random.randint(0, 99999999999)).zfill(11),
+                            "Lorem ipsum", "lorem@pec.loremit", "", ""]
+                    if not_mutually_id:
+                        data[1] = data[3]
+                        data[2] = data[3]
+                    # write the data
+                    writer.writerow(data)
+            else: # invalid data case: missing pa_id_istat, pa_id_catasto
+                for i in range(1, rows + 1):
+                    data = [i, pa_fiscalcode, "", "fake@email.com", "pa_referent_email", "pa_referent_name",
+                            random.randint(1, 100000), str(random.randint(0, 99999999999)).zfill(11),
+                            "Lorem ipsum", "lorem@pec.loremit", "", ""]
+                    # write the data
+                    writer.writerow(data)
     blob = "input/" + file
     os.system(
         f'az storage blob upload --account-name {account_name} --auth-mode key -c {container_name} -f {path}/{file} -n {blob}')


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

- `@BlobTrigger` was replaced with `@QueueueTrigger`: the queue contains the `Blob.Created` events published to System Topic via `EventGrid`;
- partition key creation logic for the `DebtPositionsTable` was added: the key is composed of the concatenation of the container (one for the corporate) and the name of the file loaded by the corporate; this change was necessary because the name of the blob (or file) is no longer unique;
- the logic of result uploading (output or error) into the correct container, i.e., the one corresponding to the corporate that uploaded the `PaymentNotice`, has been updated;

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

- These changes are necessary to move from a single container with heterogeneous corporate files to a multiple container in which each corporate has a dedicated container; now storage is partitioned by corporate.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
